### PR TITLE
fix(ember): remove overflow from main content

### DIFF
--- a/ember/app/ui/application/template.hbs
+++ b/ember/app/ui/application/template.hbs
@@ -1,6 +1,6 @@
 <main>
   <NavBar @logo={{this.config.navBarLogo}} @text={{this.config.navBarText}} />
-  <div class="uk-padding uk-overflow-auto">
+  <div class="uk-padding">
     {{outlet}}
   </div>
 </main>


### PR DESCRIPTION
fix problem with dropdown at the end of the page being cut off