### PR TITLE
feat(ember): allow admins to always edit the form

### DIFF
--- a/caluma/extensions/permissions.py
+++ b/caluma/extensions/permissions.py
@@ -91,7 +91,10 @@ class MySAGWPermission(BasePermission):
 
         case = self._get_case_for_doc(answer.document)
 
-        if not self._is_admin(info) and not (
+        if self._is_admin(info):
+            return True
+
+        if not (
             self._can_access_case(info, case)
             or self._is_own(info, answer.document.family)
         ):

--- a/caluma/extensions/permissions.py
+++ b/caluma/extensions/permissions.py
@@ -17,9 +17,16 @@ from caluma.extensions.settings import settings
 
 
 class MySAGWPermission(BasePermission):
-    def _is_admin_or_sagw(self, info):
+    def _is_admin(self, info):
         groups = info.context.user.groups
-        return "admin" in groups or "sagw" in groups
+        return "admin" in groups
+
+    def _is_sagw(self, info):
+        groups = info.context.user.groups
+        return "sagw" in groups
+
+    def _is_admin_or_sagw(self, info):
+        return self._is_admin(info) or self._is_sagw(info)
 
     def _can_access_case(self, info, case):
         case_ids = get_cases_for_user(info.context.user)
@@ -84,7 +91,7 @@ class MySAGWPermission(BasePermission):
 
         case = self._get_case_for_doc(answer.document)
 
-        if not self._is_admin_or_sagw(info) and not (
+        if not self._is_admin(info) and not (
             self._can_access_case(info, case)
             or self._is_own(info, answer.document.family)
         ):

--- a/ember/app/abilities/case.js
+++ b/ember/app/abilities/case.js
@@ -13,7 +13,7 @@ export default class CaseAbility extends BaseAbility {
   get canEdit() {
     return (
       (this.model.hasSubmitOrReviseWorkItem && this.hasAccess(this.model)) ||
-      this.isStaffOrAdmin
+      this.isAdmin
     );
   }
 

--- a/ember/app/abilities/case.js
+++ b/ember/app/abilities/case.js
@@ -12,8 +12,8 @@ export default class CaseAbility extends BaseAbility {
 
   get canEdit() {
     return (
-      (this.model.hasSubmitOrReviseWorkItem && this.hasAccess(this.model)) ||
-      this.isAdmin
+      this.isAdmin ||
+      (this.model.hasSubmitOrReviseWorkItem && this.hasAccess(this.model))
     );
   }
 

--- a/ember/app/abilities/case.js
+++ b/ember/app/abilities/case.js
@@ -11,7 +11,10 @@ export default class CaseAbility extends BaseAbility {
   }
 
   get canEdit() {
-    return this.hasAccess(this.model);
+    return (
+      (this.model.hasSubmitOrReviseWorkItem && this.hasAccess(this.model)) ||
+      this.isStaffOrAdmin
+    );
   }
 
   get canDelete() {

--- a/ember/app/ui/cases/detail/edit/controller.js
+++ b/ember/app/ui/cases/detail/edit/controller.js
@@ -6,9 +6,6 @@ export default class CasesDetailEditController extends Controller {
   @service can;
 
   get disabled() {
-    return !(
-      this.model.hasSubmitOrReviseWorkItem &&
-      this.can.can("edit case", this.model)
-    );
+    return !this.can.can("edit case", this.model);
   }
 }

--- a/ember/tests/unit/ui/cases/detail/edit/controller-test.js
+++ b/ember/tests/unit/ui/cases/detail/edit/controller-test.js
@@ -40,7 +40,7 @@ module("Unit | Controller | cases/detail/edit", function (hooks) {
         isAuthenticated: true,
         data: {
           authenticated: {
-            userinfo: { email: "lorem@ipsum.co", mysagw_groups: ["sagw"] },
+            userinfo: { email: "lorem@ipsum.co", mysagw_groups: ["admin"] },
           },
         },
       },

--- a/ember/tests/unit/ui/cases/detail/edit/controller-test.js
+++ b/ember/tests/unit/ui/cases/detail/edit/controller-test.js
@@ -7,6 +7,33 @@ module("Unit | Controller | cases/detail/edit", function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
+    ENV.APP.caluma = {};
+    ENV.APP.caluma.documentEditableTaskSlugs = ["test"];
+    this.controller = this.owner.lookup("controller:cases/detail/edit");
+    this.controller.model = {
+      hasEditableWorkItem: false,
+      accesses: [{ email: "test@test.com" }],
+    };
+  });
+
+  test("no access", function (assert) {
+    this.owner.register(
+      "service:session",
+      {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            userinfo: { email: "lorem@ipsum.co", mysagw_groups: [] },
+          },
+        },
+      },
+      { instantiate: false }
+    );
+
+    assert.true(this.controller.disabled);
+  });
+
+  test("admin access", function (assert) {
     this.owner.register(
       "service:session",
       {
@@ -19,16 +46,28 @@ module("Unit | Controller | cases/detail/edit", function (hooks) {
       },
       { instantiate: false }
     );
+
+    assert.false(this.controller.disabled);
   });
 
-  test("it is setup properly", function (assert) {
-    ENV.APP.caluma = {};
-    ENV.APP.caluma.documentEditableTaskSlugs = ["test"];
-    const controller = this.owner.lookup("controller:cases/detail/edit");
-    controller.model = {
-      hasEditableWorkItem: false,
-      accesses: [{ email: "test@test.com" }],
+  test("user access", function (assert) {
+    this.owner.register(
+      "service:session",
+      {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            userinfo: { email: "lorem@ipsum.co", mysagw_groups: [] },
+          },
+        },
+      },
+      { instantiate: false }
+    );
+    this.controller.model = {
+      hasEditableWorkItem: true,
+      accesses: [{ email: "lorem@ipsum.co" }],
     };
-    assert.true(controller.disabled);
+
+    assert.true(this.controller.disabled);
   });
 });


### PR DESCRIPTION
@open-dynaMIX there was no need for backend changes as the permissions already allow admin and sagw to always edit

The frontend permission are now the same as in the backend