### PR TITLE
chore: refactor OIDC authentication backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ api-shell_plus: ## Run shell_plus
 .PHONY: api-dev-server
 api-dev-server: ## Start backend dev server
 	@docker-compose stop api
-	@docker-compose run --user root --use-aliases --service-ports api ./manage.py runserver 0:8000
+	@docker-compose run --user root --use-aliases --service-ports api bash -c 'pip install pdbpp && python ./manage.py runserver 0.0.0.0:8000'
 
 .PHONY: makemigrations
 makemigrations: ## Make django migrations

--- a/api/mysagw/oidc_auth/authentication.py
+++ b/api/mysagw/oidc_auth/authentication.py
@@ -1,18 +1,13 @@
-import binascii
 import functools
 import hashlib
-import json
 import warnings
 from collections import namedtuple
 
-import requests
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import SuspiciousOperation
 from django.utils.encoding import force_bytes
-from josepy.b64 import b64decode
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
-from requests.auth import HTTPBasicAuth
 from simple_history.models import HistoricalRecords
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -22,79 +17,18 @@ from .models import OIDCUser
 class MySAGWAuthenticationBackend(OIDCAuthenticationBackend):
     _HistoricalRequestUser = namedtuple("User", ["id"])
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.OIDC_EMAIL_CLAIM = self.get_settings("OIDC_EMAIL_CLAIM")
-        self.OIDC_OP_INTROSPECT_ENDPOINT = self.get_settings(
-            "OIDC_OP_INTROSPECT_ENDPOINT"
-        )
-        self.OIDC_BEARER_TOKEN_REVALIDATION_TIME = self.get_settings(
-            "OIDC_BEARER_TOKEN_REVALIDATION_TIME"
-        )
-        self.OIDC_VERIFY_SSL = self.get_settings("OIDC_VERIFY_SSL", True)
-
-    def get_introspection(self, access_token, id_token, payload):
-        """Return user details dictionary."""
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-        }
-        response = requests.post(
-            self.OIDC_OP_INTROSPECT_ENDPOINT,
-            verify=self.OIDC_VERIFY_SSL,
-            headers=headers,
-            data={"token": access_token},
-            auth=HTTPBasicAuth(
-                username=self.OIDC_RP_CLIENT_ID, password=self.OIDC_RP_CLIENT_SECRET
-            ),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    @staticmethod
-    def _client_id_from_token(token):
-        try:
-            return json.loads(b64decode(token.split(".")[1])).get(
-                settings.OIDC_CLIENT_ID_CLAIM
-            )
-        except (IndexError, binascii.Error):
-            return None
-
-    def get_userinfo_or_introspection(self, access_token) -> dict:
-        client_id = self._client_id_from_token(access_token)
-
-        if client_id in [
-            settings.OIDC_RP_CLIENT_ID,
-            settings.OIDC_MONITORING_CLIENT_ID,
-        ]:
-            # check introspection (confidental client)
-            claims = self.cached_request(
-                self.get_introspection, access_token, "auth.introspection"
-            )
-            if settings.OIDC_CLIENT_ID_CLAIM not in claims:
-                raise SuspiciousOperation(
-                    f'"{settings.OIDC_CLIENT_ID_CLAIM}" not present in introspection'
-                )
-            return claims
-
-        claims = self.cached_request(self.get_userinfo, access_token, "auth.userinfo")
-
-        return claims
-
-    def get_or_create_user(self, access_token, id_token, payload):
-        """Verify claims and return user, otherwise raise an Exception."""
-
-        claims = self.get_userinfo_or_introspection(access_token)
-
+    def verify_claims(self, claims):
+        # claims for human users
         claims_to_verify = [
             settings.OIDC_ID_CLAIM,
             settings.OIDC_EMAIL_CLAIM,
             settings.OIDC_GROUPS_CLAIM,
         ]
 
-        if claims.get(settings.OIDC_CLIENT_ID_CLAIM) in [
-            settings.OIDC_RP_CLIENT_ID,
-            settings.OIDC_MONITORING_CLIENT_ID,
+        # claims for application clients
+        if claims.get(settings.OIDC_CLIENT_GRANT_USERNAME_CLAIM) in [
+            settings.OIDC_RP_CLIENT_USERNAME,
+            settings.OIDC_MONITORING_CLIENT_USERNAME,
         ]:
             claims_to_verify = [
                 settings.OIDC_ID_CLAIM,
@@ -103,6 +37,13 @@ class MySAGWAuthenticationBackend(OIDCAuthenticationBackend):
         for claim in claims_to_verify:
             if claim not in claims:
                 raise SuspiciousOperation(f'Couldn\'t find "{claim}" claim')
+
+    def get_or_create_user(self, access_token, id_token, payload):
+        """Verify claims and return user, otherwise raise an Exception."""
+
+        claims = self.cached_request(access_token, id_token, payload)
+
+        self.verify_claims(claims)
 
         # simple history reads the user_id from the current user from the request. But
         # for the user to be available in the request, authentication needs to be
@@ -117,16 +58,16 @@ class MySAGWAuthenticationBackend(OIDCAuthenticationBackend):
 
         return user
 
-    def cached_request(self, method, token, cache_prefix):
-        token_hash = hashlib.sha256(force_bytes(token)).hexdigest()
+    def cached_request(self, access_token, id_token, payload):
+        token_hash = hashlib.sha256(force_bytes(access_token)).hexdigest()
 
-        func = functools.partial(method, token, None, None)
+        func = functools.partial(self.get_userinfo, access_token, id_token, payload)
 
         with warnings.catch_warnings():
             if settings.DEBUG:  # pragma: no cover
                 warnings.simplefilter("ignore", InsecureRequestWarning)
             return cache.get_or_set(
-                f"{cache_prefix}.{token_hash}",
+                f"auth.userinfo.{token_hash}",
                 func,
-                timeout=self.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
+                timeout=settings.OIDC_BEARER_TOKEN_REVALIDATION_TIME,
             )

--- a/api/mysagw/settings.py
+++ b/api/mysagw/settings.py
@@ -120,19 +120,25 @@ OIDC_VERIFY_SSL = env.bool("OIDC_VERIFY_SSL", default=True)
 OIDC_ID_CLAIM = env.str("OIDC_ID_CLAIM", default="sub")
 OIDC_EMAIL_CLAIM = env.str("OIDC_EMAIL_CLAIM", default="email")
 OIDC_GROUPS_CLAIM = env.str("OIDC_GROUPS_CLAIM", default="mysagw_groups")
-OIDC_CLIENT_ID_CLAIM = env.str("OIDC_CLIENT_ID_CLAIM", default="clientId")
+OIDC_CLIENT_GRANT_USERNAME_CLAIM = env.str(
+    "OIDC_CLIENT_GRANT_USERNAME_CLAIM", default="preferred_username"
+)
 OIDC_BEARER_TOKEN_REVALIDATION_TIME = env.int(
     "OIDC_BEARER_TOKEN_REVALIDATION_TIME", default=0
 )
 OIDC_OP_INTROSPECT_ENDPOINT = env.str("OIDC_OP_INTROSPECT_ENDPOINT", default=None)
-OIDC_RP_CLIENT_ID = env.str("OIDC_RP_CLIENT_ID", default="test_client")
-OIDC_RP_CLIENT_SECRET = env.str(
-    "OIDC_RP_CLIENT_SECRET", default="fb13e564-75dd-4fc3-a993-3dad9064e71e"
+OIDC_MONITORING_CLIENT_USERNAME = env.str(
+    "OIDC_MONITORING_CLIENT_GRANT_VALUE", default="service-account-monitoring_client"
 )
-OIDC_MONITORING_CLIENT_ID = env.str(
-    "OIDC_MONITORING_CLIENT_ID", default="monitoring_client"
+OIDC_RP_CLIENT_USERNAME = env.str(
+    "OIDC_RP_CLIENT_GRANT_VALUE", default="service-account-caluma_admin_client"
 )
 OIDC_DRF_AUTH_BACKEND = "mysagw.oidc_auth.authentication.MySAGWAuthenticationBackend"
+
+
+# Needed to instantiate `mozilla_django_oidc.auth.OIDCAuthenticationBackend`
+OIDC_RP_CLIENT_ID = None
+OIDC_RP_CLIENT_SECRET = None
 
 # simple history
 SIMPLE_HISTORY_HISTORY_ID_USE_UUID = True

--- a/caluma/extensions/api_client.py
+++ b/caluma/extensions/api_client.py
@@ -33,6 +33,7 @@ class APIClient:
                 client_id=settings.OIDC_ADMIN_CLIENT_ID,
                 client_secret=settings.OIDC_ADMIN_CLIENT_SECRET,
                 verify=settings.API_VERIFY_SSL,
+                scope="openid",
             )
             token["expires_at_dt"] = datetime.utcfromtimestamp(int(token["expires_at"]))
 


### PR DESCRIPTION
This commit refactors our authentication backend. There is no need to call the introspection endpoint anymore, which simplifies the implementation by a lot. Additionally, the backend doesn't need to have an oidc client for verifying tokens.

Drive-by commit:
 - chore: install pdbpp when running caluma in foreground