### PR TITLE
chore: pin postgresql to 14.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   db:
-    image: postgres:14-alpine
+    image: postgres:14.7-alpine
     volumes:
       - dbdata:/var/lib/postgresql/data
       - ./postgres/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro


### PR DESCRIPTION
With postgresql 14.8, the test
`test_identity_views.py::test_identity_search[admin-SAGW-expected3]` would fail:

```
    def _execute(self, sql, params, *ignored_wrapper_args):
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                # params default might be backend specific.
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)
E               django.db.utils.OperationalError: could not load library "/usr/local/lib/postgresql/llvmjit.so": Error relocating /usr/local/lib/postgresql/llvmjit.so: LLVMBuildGEP: symbol not found

/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py:84: OperationalError
```