### PR TITLE
Revert: "chore: pin postgresql to 14.7"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   db:
-    image: postgres:14.7-alpine
+    image: postgres:14-alpine
     volumes:
       - dbdata:/var/lib/postgresql/data
       - ./postgres/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro


### PR DESCRIPTION
The upstream image was fixed over the weekend. No need to stay on 14.7 anymore.

This reverts commit 06e3c14acdb81a45ab7be0dda5935dd03e671fec.