### PR TITLE
fix: enforce filter usage for case/accesses endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ caluma-flush: ## flush the Caluma database
 caluma-foreground: ## run caluma in foreground with dev server for debugging
 	@docker-compose stop caluma
 	@docker-compose run --rm -u root --use-aliases --service-ports caluma bash -c \
-	'poetry add --lock pdbpp && poetry install --no-dev --no-root && poetry run python ./manage.py runserver 0.0.0.0:8000'
+	'poetry run pip install pdbpp && poetry run python ./manage.py runserver 0.0.0.0:8000'
 
 .PHONY: ember-lint
 ember-lint: ## lint the frontend

--- a/api/mysagw/case/filters.py
+++ b/api/mysagw/case/filters.py
@@ -13,4 +13,4 @@ class CaseAccessFilterSet(FilterSet):
 
     class Meta:
         model = models.CaseAccess
-        fields = ["case_id", "identity", "idp_id", "case_ids", "idp_ids"]
+        fields = ["idp_id", "case_ids", "idp_ids"]

--- a/api/mysagw/case/tests/test_case_views.py
+++ b/api/mysagw/case/tests/test_case_views.py
@@ -15,15 +15,21 @@ from mysagw.utils import build_url
 
 
 @pytest.mark.parametrize(
-    "filter_id,expected_count",
+    "filter_id,expected_count,expected_status",
     [
-        (None, 4),
-        ("00000000-0000-0000-0000-000000000000", 2),
-        ("11111111-1111-1111-1111-111111111111", 1),
+        (None, 0, status.HTTP_400_BAD_REQUEST),
+        ("00000000-0000-0000-0000-000000000000", 2, status.HTTP_200_OK),
+        ("11111111-1111-1111-1111-111111111111", 1, status.HTTP_200_OK),
     ],
 )
 def test_case_list(
-    db, client, filter_id, expected_count, identity_factory, case_access_factory
+    db,
+    client,
+    filter_id,
+    expected_count,
+    expected_status,
+    identity_factory,
+    case_access_factory,
 ):
     identity_0 = identity_factory(idp_id="00000000-0000-0000-0000-000000000000")
     identity_1 = identity_factory(idp_id="11111111-1111-1111-1111-111111111111")
@@ -35,10 +41,11 @@ def test_case_list(
 
     response = client.get(url, {"filter[idpId]": filter_id} if filter_id else None)
 
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == expected_status
 
-    json = response.json()
-    assert len(json["data"]) == expected_count
+    if expected_status == status.HTTP_200_OK:
+        json = response.json()
+        assert len(json["data"]) == expected_count
 
 
 @pytest.mark.parametrize(

--- a/api/mysagw/case/views.py
+++ b/api/mysagw/case/views.py
@@ -9,6 +9,7 @@ from django.utils import formats
 from django.utils.translation import get_language
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.mixins import CreateModelMixin, DestroyModelMixin, ListModelMixin
 from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import GenericViewSet
@@ -36,6 +37,14 @@ class CaseAccessViewSet(
     queryset = models.CaseAccess.objects.all()
     filterset_class = filters.CaseAccessFilterSet
     permission_classes = (IsAuthenticated & (IsAdmin | IsStaff | HasCaseAccess),)
+
+    def list(self, request, *args, **kwargs):
+        expected_keys = ["filter[idpId]", "filter[caseIds]", "filter[idpId]"]
+        if not request.GET or set(expected_keys).isdisjoint(request.GET.keys()):
+            raise ValidationError(
+                f"At least one of following filters must be used: {', '.join(expected_keys)}"
+            )
+        return super().list(request, *args, **kwargs)
 
     def get_queryset(self, *args, **kwargs):
         qs = super().get_queryset(*args, **kwargs)

--- a/ember/app/ui/cases/index/controller.js
+++ b/ember/app/ui/cases/index/controller.js
@@ -109,17 +109,11 @@ export default class CasesIndexController extends TableController {
     await Promise.resolve();
 
     try {
-      const accesses = (
+      return (
         await this.store.query("case-access", {
           filter: { idpIds: idpIds.join(",") },
         })
       ).map((access) => access.get("caseId"));
-
-      // TODO: this needs to be fixed in the backend: empty lists of ids will
-      // result in not filtering at all!
-      return accesses.length
-        ? accesses
-        : ["5131f81b-2fca-4b95-9b46-8b9d3997e665"];
     } catch (error) {
       console.error(error);
       this.notification.fromError(error);


### PR DESCRIPTION
Drive-by commit:

 - chore(make): use pip in caluma-foreground target