### PR TITLE
fix(ember): disable cache for case fetches

### DIFF
--- a/ember/app/services/case-data.js
+++ b/ember/app/services/case-data.js
@@ -20,6 +20,7 @@ export default class CaseDataService extends Service {
       {
         query: getCaseQuery,
         variables: { filter: [{ id: caseId }] },
+        fetchPolicy: "network-only",
       },
       "allCases.edges"
     );
@@ -43,6 +44,7 @@ export default class CaseDataService extends Service {
             { status: "REDO", invert: true },
           ],
         },
+        fetchPolicy: "network-only",
       },
       "allWorkItems.edges"
     );

--- a/ember/app/ui/cases/detail/index/controller.js
+++ b/ember/app/ui/cases/detail/index/controller.js
@@ -252,7 +252,7 @@ export default class CasesDetailIndexController extends Controller {
         variables: { input: { id: this.caseData.case.redoWorkItem.id } },
       });
 
-      yield this.caseData.fetchCase.perform(this.model.id);
+      yield Promise.all(this.caseData.fetch(this.model.id));
 
       this.notification.success(this.intl.t("documents.redoSuccess"));
     } catch (error) {

--- a/ember/app/ui/cases/detail/work-items/edit/form/controller.js
+++ b/ember/app/ui/cases/detail/work-items/edit/form/controller.js
@@ -61,11 +61,13 @@ export default class CasesDetailWorkItemsEditFormController extends Controller {
       return this.router.transitionTo("cases.detail.index", this.model.case.id);
     }
 
+    const fetches = [this.caseData.fetchCase.perform(this.model.case.id)];
+
     if (this.model.task.slug === "review-document") {
-      this.caseData.fetchCirculation.perform(this.model.case.id);
+      fetches.push(this.caseData.fetchCirculation.perform(this.model.case.id));
     }
 
-    this.caseData.fetchCase.perform(this.model.case.id);
+    await Promise.all(fetches);
     this.router.transitionTo("cases.detail.work-items", this.model.case.id);
   }
 }


### PR DESCRIPTION
Hitting the cache can result in old data in some cases causing navigation/ buttons to vanish/ display incorrectly