### PR TITLE
fix(caluma): fix visibility for workitem

### DIFF
--- a/caluma/extensions/visibilities.py
+++ b/caluma/extensions/visibilities.py
@@ -150,7 +150,10 @@ class CreateOrAssignVisibility(BaseVisibility):
 
         return queryset.filter(
             (
-                Q(case__family_id__in=case_ids)
+                (
+                    Q(case__family_id__in=case_ids)
+                    | Q(case__created_by_user=user.username)
+                )
                 & (
                     Q(
                         task__slug__in=[


### PR DESCRIPTION
Access is not visible for 60 seconds (cache). We also need to return the WorkItems from cases created by the requesting user.