### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# general software maintenance
+**/Dockerfile @open-dynaMIX @Yelinz
+docker-compose.yml @open-dynaMIX @Yelinz
+ember/* @Yelinz
+api/* @open-dynaMIX


### PR DESCRIPTION
Do you guys think it's worth spelling out all the paths or should we simply *wildcard* this thing?