### PR TITLE
chore: refactor mocking in tests that need caluma responses

### DIFF
--- a/api/mysagw/accounting/conftest.py
+++ b/api/mysagw/accounting/conftest.py
@@ -9,73 +9,8 @@ from mysagw.utils import build_url
 
 
 @pytest.fixture
-def receipt_mock(requests_mock):
-    def mockit(data, additional_data_available):
-        def json_callback(request, context):
-            if request.json()["query"].startswith("query DocumentId"):
-                return (
-                    {
-                        "data": {
-                            "node": {
-                                "additionalData": {
-                                    "edges": [
-                                        {"node": {"document": {"id": "GLOBAL_ID"}}},
-                                    ],
-                                },
-                            },
-                        },
-                    }
-                    if additional_data_available
-                    else {"data": {"node": {"additionalData": {"edges": []}}}}
-                )
-            return data
-
-        requests_mock.post(
-            "http://testserver/graphql",
-            status_code=200,
-            json=json_callback,
-        )
-
-        with (TEST_FILES_DIR / "small.png").open("rb") as f:
-            png = f.read()
-
-        with (TEST_FILES_DIR / "test.pdf").open("rb") as f:
-            pdf = f.read()
-
-        with (TEST_FILES_DIR / "test_encrypted.pdf").open("rb") as f:
-            pdf_encrypted = f.read()
-
-        with (TEST_FILES_DIR / "test_cover.pdf").open("rb") as f:
-            cover = f.read()
-
-        requests_mock.get(
-            "https://mysagw.local/caluma-media/download-url-png",
-            status_code=status.HTTP_200_OK,
-            content=png,
-            headers={"content-type": "image/png"},
-        )
-
-        requests_mock.get(
-            "https://mysagw.local/caluma-media/download-url-png2",
-            status_code=status.HTTP_200_OK,
-            content=png,
-            headers={"content-type": "image/png"},
-        )
-
-        requests_mock.get(
-            "https://mysagw.local/caluma-media/download-url-pdf",
-            status_code=status.HTTP_200_OK,
-            content=pdf,
-            headers={"CONTENT-TYPE": "application/pdf"},
-        )
-
-        requests_mock.get(
-            "https://mysagw.local/caluma-media/download-url-pdf-encrypted",
-            status_code=status.HTTP_200_OK,
-            content=pdf_encrypted,
-            headers={"CONTENT-TYPE": "application/pdf"},
-        )
-
+def dms_cover_mock(requests_mock):
+    def mockit(failure=False):
         matcher = re.compile(
             build_url(
                 settings.DOCUMENT_MERGE_SERVICE_URL,
@@ -86,11 +21,21 @@ def receipt_mock(requests_mock):
             ),
         )
 
-        return requests_mock.post(
-            matcher,
-            status_code=status.HTTP_200_OK,
-            content=cover,
-            headers={"CONTENT-TYPE": "application/pdf"},
-        )
+        mock_args = {
+            "status_code": status.HTTP_400_BAD_REQUEST,
+            "json": ["something went wrong"],
+            "headers": {"CONTENT-TYPE": "application/json"},
+        }
+
+        if not failure:
+            with (TEST_FILES_DIR / "test_cover.pdf").open("rb") as f:
+                cover = f.read()
+
+            mock_args["status_code"] = status.HTTP_200_OK
+            del mock_args["json"]
+            mock_args["content"] = cover
+            mock_args["headers"] = {"CONTENT-TYPE": "application/pdf"}
+
+        return requests_mock.post(matcher, **mock_args)
 
     return mockit

--- a/api/mysagw/accounting/tests/additional_data_caluma_response.py
+++ b/api/mysagw/accounting/tests/additional_data_caluma_response.py
@@ -24,14 +24,14 @@ CALUMA_DATA_FULL = {
                                                                         },
                                                                         "filesValue": [
                                                                             {
-                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-png",
+                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-small.png",
                                                                                 "metadata": {
                                                                                     "content_type": "image/png",
                                                                                 },
                                                                                 "name": "File 1",
                                                                             },
                                                                             {
-                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-png2",
+                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-wide.png",
                                                                                 "metadata": {
                                                                                     "content_type": "image/png",
                                                                                 },
@@ -57,7 +57,7 @@ CALUMA_DATA_FULL = {
                                                                     "node": {
                                                                         "filesValue": [
                                                                             {
-                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-pdf",
+                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-test.pdf",
                                                                                 "metadata": {
                                                                                     "content_type": "application/pdf",
                                                                                 },
@@ -79,7 +79,7 @@ CALUMA_DATA_FULL = {
                                                                     "node": {
                                                                         "filesValue": [
                                                                             {
-                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-pdf-encrypted",
+                                                                                "downloadUrl": "https://mysagw.local/caluma-media/download-url-test_encrypted.pdf",
                                                                                 "metadata": {
                                                                                     "content_type": "application/pdf",
                                                                                 },

--- a/api/mysagw/accounting/tests/test_views.py
+++ b/api/mysagw/accounting/tests/test_views.py
@@ -1,7 +1,4 @@
-import re
-
 import pytest
-from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
 
@@ -9,12 +6,12 @@ from mysagw.accounting.tests.additional_data_caluma_response import (
     CALUMA_DATA_EMPTY,
     CALUMA_DATA_FULL,
 )
-from mysagw.utils import build_url
 
 
+@pytest.mark.usefixtures("_caluma_files_mock")
 @pytest.mark.freeze_time("1970-01-01")
 @pytest.mark.parametrize(
-    "client,dms_failure,caluma_data,dms_mock_calls,expected_status",
+    "client,dms_failure,caluma_data,dms_mock_call_count,expected_status",
     [
         ("user", False, CALUMA_DATA_FULL, 0, status.HTTP_403_FORBIDDEN),
         ("staff", False, CALUMA_DATA_FULL, 2, status.HTTP_200_OK),
@@ -29,29 +26,28 @@ def test_get_receipts(
     client,
     dms_failure,
     caluma_data,
-    dms_mock_calls,
+    dms_mock_call_count,
     expected_status,
-    receipt_mock,
-    requests_mock,
+    graphql_mock,
+    dms_cover_mock,
     snapshot,
 ):
-    dms_mock = receipt_mock(caluma_data, caluma_data == CALUMA_DATA_FULL)
-    if dms_failure:
-        matcher = re.compile(
-            build_url(
-                settings.DOCUMENT_MERGE_SERVICE_URL,
-                "template",
-                ".*",
-                "merge",
-                trailing=True,
-            ),
-        )
-        dms_mock = requests_mock.post(
-            matcher,
-            status_code=status.HTTP_400_BAD_REQUEST,
-            json=["something went wrong"],
-            headers={"CONTENT-TYPE": "application/json"},
-        )
+    graphql_id_response = {
+        "data": {
+            "node": {
+                "additionalData": {
+                    "edges": [
+                        {"node": {"document": {"id": "GLOBAL_ID"}}},
+                    ],
+                },
+            },
+        },
+    }
+    if caluma_data == CALUMA_DATA_EMPTY:
+        graphql_id_response = {"data": {"node": {"additionalData": {"edges": []}}}}
+    graphql_mock(graphql_id_response, caluma_data)
+
+    dms_mock = dms_cover_mock(dms_failure)
 
     case_id = "e535ac0c-f3be-4a36-b2d4-1ef405ec71c8"
     url = reverse("receipts", args=[case_id])
@@ -59,8 +55,8 @@ def test_get_receipts(
     response = client.get(url)
 
     assert response.status_code == expected_status
-    assert len(dms_mock.request_history) == dms_mock_calls
-    for i in range(dms_mock_calls):
+    assert len(dms_mock.request_history) == dms_mock_call_count
+    for i in range(dms_mock_call_count):
         snapshot.assert_match(dms_mock.request_history[i].json())
 
     if dms_failure:

--- a/api/mysagw/caluma_document_parser.py
+++ b/api/mysagw/caluma_document_parser.py
@@ -394,6 +394,15 @@ class DocumentParser:
 
 
 def generate_pdf(parser, append_to=None):
+    """
+    Generate a PDF from the parser data.
+
+    This helper function takes a DocumentParser instance and generates a PDF file
+    containing the whole document, followed by all render-able attachments.
+    Optionally, a PDF can be supplied (`append_to`), that will be put at the top of the
+    resulting PDF.
+    """
+
     def merge_files_to_pdf(pdf):
         parser.merger.merge(0, pdf)
         if append_to:
@@ -421,5 +430,5 @@ def generate_pdf(parser, append_to=None):
     if dms_document_response.status_code != status.HTTP_200_OK:
         raise DMSException(dms_document_response)
 
-    # Then we merge the attachemnts to the newly generated PDF
+    # Then we merge the attachments to the newly generated PDF
     return merge_files_to_pdf(io.BytesIO(dms_document_response.content))

--- a/api/mysagw/case/conftest.py
+++ b/api/mysagw/case/conftest.py
@@ -121,31 +121,3 @@ def credit_approval_mock(requests_mock):
         )
 
     return mockit
-
-
-@pytest.fixture
-def application_mock(requests_mock):
-    def mockit(data):
-        def json_callback(request, context):
-            if request.json()["query"].startswith("query DocumentId"):
-                return {"data": {"node": {"document": {"id": "GLOBAL_ID"}}}}
-            return data
-
-        requests_mock.post(
-            "http://testserver/graphql",
-            status_code=200,
-            json=json_callback,
-        )
-
-        for file in ["small.png", "big.png", "long.png", "wide.png"]:
-            with (TEST_FILES_DIR / file).open("rb") as f:
-                png = f.read()
-
-            requests_mock.get(
-                f"https://mysagw.local/caluma-media/download-url-{file}",
-                status_code=status.HTTP_200_OK,
-                content=png,
-                headers={"CONTENT-TYPE": "image/png"},
-            )
-
-    return mockit

--- a/api/mysagw/case/tests/test_case_views.py
+++ b/api/mysagw/case/tests/test_case_views.py
@@ -305,20 +305,22 @@ def test_download_dms_failure(
     }
 
 
+@pytest.mark.usefixtures("_caluma_files_mock")
 @pytest.mark.parametrize("dms_failure", [False, True])
 @pytest.mark.parametrize("data", [CALUMA_DATA_FULL, CALUMA_DATA_EMPTY])
 @pytest.mark.parametrize("identity__idp_id", ["e5dabdd0-bafb-4b75-82d2-ccf9295b623b"])
 def test_download_application(
     dms_mock,
     requests_mock,
-    application_mock,
+    graphql_mock,
     client,
     identity,
     snapshot,
     dms_failure,
     data,
 ):
-    application_mock(data)
+    graphql_id_response = {"data": {"node": {"document": {"id": "GLOBAL_ID"}}}}
+    graphql_mock(graphql_id_response, data)
     if dms_failure:
         requests_mock.post(
             build_url(


### PR DESCRIPTION
This commit streamlines almost duplicate code in the conftest files of the accounting and case apps into the main conftest file.

Drive-by commit:
 - docs: add docstring & fix typo in comment