### PR TITLE
ci: build ember in CI

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -35,6 +35,8 @@ jobs:
             path: api
           - image: ${{ github.repository }}-caluma
             path: caluma
+          - image: ${{ github.repository }}-ember
+            path: ember
     permissions:
       packages: write
       contents: read

--- a/ember/config/environment.js
+++ b/ember/config/environment.js
@@ -19,8 +19,7 @@ module.exports = function (environment) {
       userinfoEndpoint: "/userinfo",
       afterLogoutUri: "/login",
       host:
-        process.env.OIDC_HOST ||
-        "https://mysagw.local/auth/realms/mysagw/protocol/openid-connect",
+        process.env.OIDC_HOST || "/auth/realms/mysagw/protocol/openid-connect",
       enablePkce: true,
     },
     localizedModel: {
@@ -179,6 +178,9 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV["ember-simple-auth-oidc"].host =
+      process.env.OIDC_HOST ||
+      "https://mysagw.local/auth/realms/mysagw/protocol/openid-connect";
   }
 
   if (environment === "test") {


### PR DESCRIPTION
Only when Keycloak and frontend are on the same host can relative urls be used.