### PR TITLE
feat(form): introduce table summary generator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         stages: [commit]
         name: api-ruff
         language: system
-        entry: /bin/sh -c 'cd ./api/ && ruff check . --show-source --fix'
+        entry: /bin/sh -c 'cd ./api/ && ruff check . --output-format=full --fix'
         types: [python]
       - id: caluma-ruff-format
         stages: [ commit ]
@@ -23,7 +23,7 @@ repos:
         stages: [ commit ]
         name: caluma-ruff
         language: system
-        entry: /bin/sh -c 'cd ./caluma/ && ruff check . --config ../api/pyproject.toml --show-source --fix'
+        entry: /bin/sh -c 'cd ./caluma/ && ruff check . --config ../api/pyproject.toml --output-format=full --fix'
         types: [ python ]
       - id: gitlint
         stages: [commit-msg]

--- a/caluma/Dockerfile
+++ b/caluma/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/projectcaluma/caluma:10.1.1
+FROM ghcr.io/projectcaluma/caluma:10.5.1
 
 ENV PATH="${HOME}/.local/bin:${PATH}"
 

--- a/caluma/data/form-config.json
+++ b/caluma/data/form-config.json
@@ -833,7 +833,9 @@
                 "max_value": null,
                 "min_value": null
             },
-            "meta": {"waehrung": "chf"},
+            "meta": {
+                "waehrung": "chf"
+            },
             "data_source": null,
             "row_form": null,
             "sub_form": null,
@@ -926,7 +928,9 @@
             "hint_text": "{\"de\": null, \"en\": null, \"fr\": null}",
             "static_content": "{\"de\": \"\", \"en\": \"\", \"fr\": \"\"}",
             "configuration": {},
-            "meta": {"waehrung": "chf"},
+            "meta": {
+                "waehrung": "chf"
+            },
             "data_source": null,
             "row_form": null,
             "sub_form": null,
@@ -1391,6 +1395,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Genehmigt\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1407,6 +1412,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Abgelehnt\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1423,6 +1429,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Weitere Daten\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1439,6 +1446,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Negativ Entscheid\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1455,6 +1463,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Abschluss\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1471,6 +1480,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Betrag festlegen\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1487,6 +1497,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"Weiterf\\u00fchrung\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1503,6 +1514,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Abgewiesen\", \"en\": \"Dismissed\", \"fr\": \"Rejet\\u00e9\"}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1519,6 +1531,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"R\\u00fcckweisung\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1535,6 +1548,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Zur\\u00fcckgezogen\", \"en\": \"Withdrawn\", \"fr\": \"Retir\\u00e9\"}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1551,6 +1565,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Abschluss\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1567,6 +1582,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Abschluss\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1583,6 +1599,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"Weiterf\\u00fchrung\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1599,6 +1616,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": \"R\\u00fcckweisung\", \"en\": null, \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1615,6 +1633,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"1\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1631,6 +1650,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"2\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1647,6 +1667,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"3\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1663,6 +1684,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"4\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1679,6 +1701,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"5\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1695,6 +1718,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"6\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1711,6 +1735,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"7\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null
@@ -1727,6 +1752,7 @@
             "modified_by_user": null,
             "modified_by_group": null,
             "label": "{\"de\": null, \"en\": \"2021\", \"fr\": null}",
+            "is_hidden": "false",
             "is_archived": false,
             "meta": {},
             "source": null

--- a/caluma/extensions/events/__init__.py
+++ b/caluma/extensions/events/__init__.py
@@ -2,4 +2,4 @@
 # automatically without having to define each file as caluma event receiver
 # module
 
-from . import case, work_item  # noqa: F401
+from . import case, form, work_item  # noqa: F401

--- a/caluma/extensions/events/form.py
+++ b/caluma/extensions/events/form.py
@@ -1,0 +1,123 @@
+import csv
+import io
+import logging
+
+from django.db import transaction
+from django.db.models.signals import post_save
+
+from caluma.caluma_core.events import on
+from caluma.caluma_form import models as caluma_form_models
+
+from ..settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+@on(post_save, sender=caluma_form_models.AnswerDocument, raise_exception=True)
+@transaction.atomic
+def update_table_summary(instance, *args, **kwargs):
+    """
+    Update table summary.
+
+    If a table question has the `meta` attributes `summary-question` and
+    `summary-mode` set, then upon save of a table row (or answer within),
+    a summary of the table will be written, as follows:
+
+    In the parent document (the one containing the table answer), the
+    referenced summary question is updated to contain a summary, calculated
+    according to the given summary mode.
+
+    Currently, only `csv` is allowed as a summary mode, but the code can be extended
+    to support sums, averages, etc. as needed.
+    """
+    question = instance.answer.question
+    main_document = instance.answer.document
+
+    summary_question = question.meta.get("summary-question")
+    summary_mode = question.meta.get("summary-mode")
+
+    if not summary_question and not summary_mode:
+        # no summary requested
+        return
+
+    logger.debug("Updating table summary: tq=%s", instance.answer.question_id)
+
+    if not summary_question or not summary_mode:
+        logger.warning(
+            "Updating table summary: missing info in TQ meta: " "sq=%s, sm=%s",
+            summary_question,
+            summary_mode,
+        )
+        return
+
+    logger.debug("Updating table summary: sq=%s sm=%s", summary_question, summary_mode)
+
+    summary_answer, _ = caluma_form_models.Answer.objects.get_or_create(
+        document=main_document, question_id=summary_question
+    )
+
+    summary_modes = {"csv": _make_csv_summary}
+
+    summary_func = summary_modes.get(summary_mode)
+    if not summary_func:
+        logger.warning(
+            'Updating table summary: summary mode "%s" does not exist. '
+            "Must be one of %s",
+            summary_mode,
+            settings.TABLE_SUMMARY_MODES,
+        )
+        return
+
+    summary_answer.value = summary_func(instance.answer)
+    summary_answer.save()
+
+
+@on(post_save, sender=caluma_form_models.Answer, raise_exception=True)
+@transaction.atomic
+def update_table_summary_from_row(instance, *args, **kwargs):
+    ad = caluma_form_models.AnswerDocument.objects.filter(
+        document=instance.document
+    ).first()
+    if not ad:
+        return
+
+    # AnswerDocument available, we're in a table
+    # Make sure the summary (if any) is being updated
+    update_table_summary(instance=ad)
+
+
+def _make_csv_summary(table_answer):
+    def get_lines(answer_docs, row_question_slugs):
+        for ad in answer_docs:
+            result = {}
+            answer_data = {
+                a.question.slug: a.value
+                for a in ad.document.answers.filter(question_id__in=row_question_slugs)
+            }
+            for question_slug in row_question_slugs:
+                result[question_slug] = answer_data.get(question_slug, "")
+            yield result
+
+    logger.debug("Making CSV summary for %s", table_answer.question)
+    answer_docs = caluma_form_models.AnswerDocument.objects.filter(
+        answer=table_answer
+    ).order_by("-sort")
+    row_question_slugs = _sorted_form_question_slugs(table_answer.question.row_form)
+
+    with io.StringIO() as csvfile:
+        writer = csv.DictWriter(
+            csvfile,
+            fieldnames=row_question_slugs,
+            delimiter=";",
+            quoting=csv.QUOTE_MINIMAL,
+        )
+        writer.writeheader()
+        for line in get_lines(answer_docs, row_question_slugs):
+            writer.writerow(line)
+
+        return csvfile.getvalue()
+
+
+def _sorted_form_question_slugs(form):
+    fqs = caluma_form_models.FormQuestion.objects.filter(form=form).order_by("-sort")
+    return [fq.question.slug for fq in fqs]

--- a/caluma/extensions/settings.py
+++ b/caluma/extensions/settings.py
@@ -184,3 +184,5 @@ settings.LOGGING = {
         },
     },
 }
+
+settings.TABLE_SUMMARY_MODES = ["csv"]

--- a/caluma/extensions/validations.py
+++ b/caluma/extensions/validations.py
@@ -1,9 +1,11 @@
 from django.utils import timezone
 from localized_fields.value import LocalizedValue
 from rest_framework import exceptions
+from rest_framework.exceptions import ValidationError
 
 from caluma.caluma_core.validations import BaseValidation, validation_for
-from caluma.caluma_form.schema import SaveDocumentDateAnswer
+from caluma.caluma_form.models import Question
+from caluma.caluma_form.schema import SaveDocumentDateAnswer, SaveTableQuestion
 
 from .settings import settings
 
@@ -26,5 +28,37 @@ class CustomValidation(BaseValidation):
                     },
                 ).translate(),
             )
+
+        return data
+
+    @validation_for(SaveTableQuestion)
+    def validate_table_summary_config(self, mutation, data, info):
+        summary_question = data["meta"].get("summary-question")
+        summary_mode = data["meta"].get("summary-mode")
+
+        if not summary_question and not summary_mode:
+            return data
+
+        if summary_mode and not summary_question:
+            msg = (
+                '"[meta] summary-question" must be provided when setting "summary-mode"'
+            )
+            raise ValidationError(msg)
+
+        if summary_question and not summary_mode:
+            msg = (
+                '"[meta] summary-mode" must be provided when setting "summary-question"'
+            )
+            raise ValidationError(msg)
+
+        if summary_mode not in settings.TABLE_SUMMARY_MODES:
+            msg = f'"[meta] summary-mode" must be one of {settings.TABLE_SUMMARY_MODES} when setting "summary-question"'
+            raise ValidationError(msg)
+
+        if not Question.objects.filter(slug=summary_question).exists():
+            msg = (
+                '"[meta] summary-question" must be a valid slug of an existing question'
+            )
+            raise ValidationError(msg)
 
         return data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - db
 
   caluma:
-    image: ghcr.io/projectcaluma/caluma:10.1.1
+    image: ghcr.io/projectcaluma/caluma:10.5.1
     build:
       context: caluma
     environment:


### PR DESCRIPTION
This generates a summary of table questions if the table question is configured to do so.

Currently, only a CSV mode is available, but the code is easily extensible to support other summary types as well.

To use it, proceed as follows:

* Create a new (multiline text) question on the form where your table question resides. It will be used to store the summary. Ideally, you should configure it to be hidden.
* Configure the meta attributes of the table question and add the following keys:
  - `summary-question`: Slug of the summary question just created above
  - `summary-mode`: Calculation mode on how to generate the summary (currently only `"csv"` available)
