### PR TITLE
feat: also update table summaries on table question change

### DIFF
--- a/caluma/extensions/events/form.py
+++ b/caluma/extensions/events/form.py
@@ -86,6 +86,22 @@ def update_table_summary_from_row(instance, *args, **kwargs):
     update_table_summary(instance=ad)
 
 
+@on(post_save, sender=caluma_form_models.Question, raise_exception=True)
+@transaction.atomic
+def update_table_summary_from_table_question(instance, *args, **kwargs):
+    if instance.type != "table" or "summary-question" not in instance.meta:
+        return
+
+    # Call `update_table_summary()` for one AnswerDocument per every existing Answer
+    updated_answers = []
+    for ad in caluma_form_models.AnswerDocument.objects.filter(
+        answer__question_id=instance.slug
+    ):
+        if ad.answer not in updated_answers:
+            updated_answers.append(ad.answer)
+            update_table_summary(instance=ad)
+
+
 def _make_csv_summary(table_answer):
     def get_lines(answer_docs, row_question_slugs):
         for ad in answer_docs:


### PR DESCRIPTION
This makes sure a newly applied summary config leads to the generation of all the summaries. This has the potential of timing out, if there is a massive amount of Answers. We expect them to be in the lower 100s, so this doesn't justify an async approach.