### PR TITLE
fix: do never link users with organisation identities

### DIFF
--- a/ember/app/router.js
+++ b/ember/app/router.js
@@ -12,6 +12,7 @@ const resetNamespace = true;
 //eslint-disable-next-line array-callback-return
 Router.map(function () {
   this.route("login");
+  this.route("support");
   this.route("notfound", { path: "/*path" });
 
   this.route("protected", { path: "/" }, function () {

--- a/ember/app/ui/support/route.js
+++ b/ember/app/ui/support/route.js
@@ -1,0 +1,3 @@
+import Route from "@ember/routing/route";
+
+export default class SupportRoute extends Route {}

--- a/ember/app/ui/support/template.hbs
+++ b/ember/app/ui/support/template.hbs
@@ -1,0 +1,10 @@
+<div class="uk-text-center">
+  <h1>{{t "support.title"}}</h1>
+  <h3>
+    {{t "support.subtitle"}}
+    <a href="mailto:sagw@sagw.ch" target="_blank" rel="noopener noreferrer">
+      {{! template-lint-disable no-bare-strings }}
+      sagw@sagw.ch
+    </a>
+  </h3>
+</div>

--- a/ember/translations/support/de.yaml
+++ b/ember/translations/support/de.yaml
@@ -1,0 +1,3 @@
+support:
+  title: "Ein Fehler ist aufgetreten."
+  subtitle: "Bitte wenden Sie sich an"

--- a/ember/translations/support/en.yaml
+++ b/ember/translations/support/en.yaml
@@ -1,0 +1,3 @@
+support:
+  title: "An error has occurred."
+  subtitle: "Please contact"

--- a/ember/translations/support/fr.yaml
+++ b/ember/translations/support/fr.yaml
@@ -1,0 +1,3 @@
+support:
+  title: "Une erreur s'est produite."
+  subtitle: "Veuillez contacter"


### PR DESCRIPTION
This is the first step to resolve this issue. This fix prevents
organisation Identities to be linked with keycloak users. This could
potentially lead to a situation, where a user can make a keycloak
account with their email address, but then be unable to login to mySAGW,
if the Email is already set on an organisation Identity, due to the unique
constraint on the email field.