### PR TITLE
feat: prevent org admins from changing fields on the organisation

### DIFF
--- a/api/mysagw/identity/serializers.py
+++ b/api/mysagw/identity/serializers.py
@@ -309,6 +309,7 @@ class MyOrgsSerializer(MeSerializer):
             "first_name",
             "last_name",
             "salutation",
+            "title",
             "language",
             "is_organisation",
             "organisation_name",
@@ -320,6 +321,13 @@ class MyOrgsSerializer(MeSerializer):
         )
         extra_kwargs = {
             "idp_id": {"read_only": True},
+            "email": {"read_only": True},
+            "organisation_name": {"read_only": True},
+            "first_name": {"read_only": True},
+            "last_name": {"read_only": True},
+            "salutation": {"read_only": True},
+            "title": {"read_only": True},
+            "language": {"read_only": True},
             "is_organisation": {"read_only": True},
             "is_expert_association": {"read_only": True},
             "is_advisory_board": {"read_only": True},

--- a/api/mysagw/identity/tests/test_me_views.py
+++ b/api/mysagw/identity/tests/test_me_views.py
@@ -96,9 +96,11 @@ def test_me_update(db, client):
     "authorized",
     [True, False],
 )
-def test_my_orgs_update(db, client, authorized, membership_factory):
+def test_my_orgs_update_readonly(db, client, authorized, membership_factory):
     identity = client.user.identity
     membership = membership_factory(identity=identity, authorized=authorized)
+    membership.organisation.organisation_name = "Foo"
+    membership.organisation.save()
 
     url = reverse("my-orgs-detail", args=[str(membership.organisation.pk)])
 
@@ -106,7 +108,7 @@ def test_my_orgs_update(db, client, authorized, membership_factory):
         "data": {
             "type": "identities",
             "id": str(membership.organisation.pk),
-            "attributes": {"organisation-name": "Foo"},
+            "attributes": {"organisation-name": "Bar"},
         },
     }
 

--- a/ember/app/ui/components/identity-form/template.hbs
+++ b/ember/app/ui/components/identity-form/template.hbs
@@ -59,10 +59,7 @@
       <Form.input
         @label={{t "components.identity-form.label.organisationName"}}
         @name="organisationName"
-        @disabled={{or
-          (cannot "edit identity" this.changeset.data)
-          @readOnlyView
-        }}
+        @disabled="true"
       />
     {{/if}}
     <div class="uk-child-width-expand@s" uk-grid>
@@ -77,6 +74,7 @@
           @disabled={{or
             (cannot "edit identity" this.changeset.data)
             @readOnlyView
+            @customEndpoint
           }}
         />
       </div>
@@ -91,6 +89,7 @@
           @disabled={{or
             (cannot "edit identity" this.changeset.data)
             @readOnlyView
+            @customEndpoint
           }}
         />
       </div>
@@ -103,6 +102,7 @@
           @disabled={{or
             (cannot "edit identity" this.changeset.data)
             @readOnlyView
+            @customEndpoint
           }}
         />
       </div>
@@ -113,6 +113,7 @@
           @disabled={{or
             (cannot "edit identity" this.changeset.data)
             @readOnlyView
+            @customEndpoint
           }}
         />
       </div>
@@ -135,6 +136,7 @@
               this.changeset.idpId
               (cannot "edit identity" this.changeset.data)
               @readOnlyView
+              @customEndpoint
             }}
             value={{field.value}}
             {{on "input" (fn this.eventTarget field.update)}}
@@ -165,6 +167,7 @@
       @disabled={{or
         (cannot "edit identity" this.changeset.data)
         @readOnlyView
+        @customEndpoint
       }}
     />
 
@@ -175,11 +178,15 @@
           @disabled={{cannot "edit identity" this.changeset.data}}
         />
       </div>
-    {{else if (not @readOnlyView)}}
+    {{else if (not @readOnlyView @customEndpoint)}}
       <Form.input
         @label={{t "components.identity-form.label.comment"}}
         @name="comment"
         @type="textarea"
+        @disabled={{or
+        (cannot "edit identity" this.changeset.data)
+        @customEndpoint
+      }}
       />
 
       <p class="uk-flex uk-flex-between">


### PR DESCRIPTION
This commit makes the main fields of an organisation for organisation admins read-only.

Additionally this fixes two bugs:

1. Fetch title from backend (was always None)
2. Do not display comment field (was always empty)