### PR TITLE
fix: set status for canceled cases

### DIFF
--- a/caluma/extensions/settings.py
+++ b/caluma/extensions/settings.py
@@ -63,14 +63,22 @@ settings.LOCALIZED_FIELDS_EXPERIMENTAL = False
 
 # Case
 
+# Define user facing statuses according to Tasks of ready WorkItems
 settings.CASE_STATUS = {
     "submit-document": "submit",
     "review-document": "audit",
+    "circulation": "audit",
+    "decision-and-credit": "audit",
     "revise-document": "revise",
     "additional-data": "submit-receipts",
+    "additional-data-form": "submit-receipts",
+    "advance-credits": "submit-receipts",
     "define-amount": "decision",
     "complete-document": "decision",
 }
+# Additional statuses that can be set in events independently of Task slugs:
+# canceled
+# complete
 
 settings.APPLICANT_TASK_SLUGS = [
     "submit-document",

--- a/caluma/extensions/tests/test_events.py
+++ b/caluma/extensions/tests/test_events.py
@@ -606,7 +606,7 @@ def add_table_with_summary(
         is_required="true",
         is_hidden="false",
     )
-    form_question_factory(form=row_form, question=row_question_1)
+    form_question_factory(form=row_form, question=row_question_1, sort=3)
 
     row_question_2 = question_factory(
         type=Question.TYPE_TEXT,
@@ -615,7 +615,7 @@ def add_table_with_summary(
         is_required="true",
         is_hidden="false",
     )
-    form_question_factory(form=row_form, question=row_question_2)
+    form_question_factory(form=row_form, question=row_question_2, sort=2)
 
     # Only set English label to test fallback
     row_question_3 = question_factory(
@@ -626,14 +626,14 @@ def add_table_with_summary(
         is_hidden="false",
     )
 
+    form_question_factory(form=row_form, question=row_question_3, sort=1)
+
     question_option_factory(
         question=row_question_3, option=option_factory(slug="o1", label="option1 label")
     )
     question_option_factory(
         question=row_question_3, option=option_factory(slug="o2", label="option2 label")
     )
-
-    form_question_factory(form=row_form, question=row_question_3)
 
     question_factory(type=Question.TYPE_TEXTAREA, slug="summary", is_hidden="true")
     question_factory(type=Question.TYPE_TEXTAREA, slug="summary2", is_hidden="true")

--- a/ember/translations/documents/de.yaml
+++ b/ember/translations/documents/de.yaml
@@ -57,6 +57,7 @@ documents:
     submit-receipts: "Belege einreichen"
     decision: "Entscheid"
     complete: "Abgeschlossen"
+    canceled: "Abgebrochen"
 
   new:
     title: "Gesuch eröffnen"

--- a/ember/translations/documents/en.yaml
+++ b/ember/translations/documents/en.yaml
@@ -57,6 +57,7 @@ documents:
     submit-receipts: "Submit receipts"
     decision: "Decision"
     complete: "Completed"
+    canceled: "Canceled"
 
   new:
     title: "Create a new application"

--- a/ember/translations/documents/fr.yaml
+++ b/ember/translations/documents/fr.yaml
@@ -57,6 +57,7 @@ documents:
     submit-receipts: "Joindre des annexes"
     decision: "Décision"
     complete: "Bouclée"
+    canceled: "Annulé"
 
   new:
     title: "Ouvrir une nouvelle requête"

--- a/next_deployment.md
+++ b/next_deployment.md
@@ -1,6 +1,38 @@
 # Manual steps for next deployment
 
 
-## Configure token lifespan
+### Fix case statuses
 
-Set `Access Token Lifespan` to 5 minutes in Keycloak.
+ - Remove status from Cases not stemming from the `document-review` Workflow
+ - Set cancelled cases to `canceled`
+
+Run in Caluma Django shell:
+
+```python
+from caluma.caluma_workflow.models import Case
+
+
+def status_removal():
+    cases = Case.objects.exclude(workflow__slug="document-review").filter(
+        meta__status__isnull=False
+    )
+    print(f"Unset status of {cases.count()} Cases.")
+    for case in cases:
+        del case.meta["status"]
+        case.save()
+
+
+def set_cancelled_status():
+    cases = Case.objects.filter(
+        workflow__slug="document-review", status=Case.STATUS_CANCELED
+    )
+    print(f'Set status of {cases.count()} canceled Cases to "canceled".')
+    for case in cases:
+        case.meta["status"] = "canceled"
+        case.save()
+
+
+status_removal()
+set_cancelled_status()
+
+```


### PR DESCRIPTION
Cancelled cases are still accessible via their URL. So the status needs
to be set correctly. This commit adds a new status `canceled` and
sets it on cancelation of a case.

Additionally the event handlers were refactored in the following way:

 - only cases with the `document-review` Workflow get a status applied.
 - The status is set on every change of ready WorkItems, not only on the
   expected forward changes. This makes sure, that the status is also
   correct, if a Case was closed and then reopened.


### drive-by commit

 - chore(caluma): fix flaky test
