### PR TITLE
fix(caluma): Set status of discarded circulations and their work_items

### DIFF
--- a/next_deployment.md
+++ b/next_deployment.md
@@ -11,5 +11,26 @@ docker compose run --rm api python manage.py upload_template \
     credit-approval-de.docx \
     credit-approval-fr.docx \
     credit-approval-en.docx \
-    application.docx    
+    application.docx
+```
+
+## Fix dangling circulations
+
+```bash
+docker compose run --rm caluma poetry run ./manage.py shell
+```
+
+```python
+from caluma.caluma_workflow.models import Case, WorkItem
+
+cases = Case.objects.filter(parent_work_item__isnull=True, document__form__slug="circulation-form")
+print(f"Fixing {cases.count()} dangling circulations...")
+for case in cases:
+    for wi in case.work_items.all():
+        wi.status = WorkItem.STATUS_CANCELED
+        # wi.save()
+    case.status = Case.STATUS_CANCELED
+    # case.save()
+
+print("Done.")
 ```


### PR DESCRIPTION
This commit makes sure the status discarded circulations and their workitems is set to `canceled`.