### PR TITLE
feat: display advance credits answers in remark

### DIFF
--- a/caluma/data/workflow-config.json
+++ b/caluma/data/workflow-config.json
@@ -55,7 +55,7 @@
         "created_by_group": "admin",
         "modified_by_user": null,
         "modified_by_group": null,
-        "name": "{\"de\": \"Vorschusszahlung\", \"en\": \"Advance payment\", \"fr\": \"Versement d\\u2019une avance\"}",
+        "name": "{\"de\": \"Vorschusszahlung und Notizen\", \"en\": \"Advance payment and notes\", \"fr\": \"Paiement anticip\\u00e9 et remarques\"}",
         "description": "{\"de\": null, \"en\": null, \"fr\": null}",
         "type": "complete_task_form",
         "meta": {},

--- a/caluma/extensions/settings.py
+++ b/caluma/extensions/settings.py
@@ -106,6 +106,11 @@ settings.REVISION_QUESTIONS = {
         "define-amount-remark",
         "define-amount-decision",
     ],
+    "advance-credits": [
+        "advance-credit-date",
+        "advance-credit-amount-float",
+        "priorisierung-der-antrage-kommentar",
+    ],
 }
 
 settings.APPLICANT_VISIBLE_TASKS = settings.APPLICANT_TASK_SLUGS + list(

--- a/caluma/extensions/visibilities.py
+++ b/caluma/extensions/visibilities.py
@@ -53,9 +53,7 @@ class CreateOrAssignVisibility(BaseVisibility):
         return queryset.filter(
             Q(
                 document__family__in=self.filter_queryset_for_document(
-                    None,
-                    form_models.Document.objects,
-                    info,
+                    None, form_models.Document.objects, info, []
                 ),
             )
             | (

--- a/ember/app/gql/queries/get-case.graphql
+++ b/ember/app/gql/queries/get-case.graphql
@@ -35,6 +35,9 @@ query getCase($filter: [CaseFilterSetType]) {
                 }
               }
               document {
+                form {
+                  name
+                }
                 answers(
                   filter: [
                     {
@@ -47,6 +50,9 @@ query getCase($filter: [CaseFilterSetType]) {
                         "decision-and-credit-decision"
                         "define-amount-decision"
                         "gesprochener-rahmenkredit"
+                        "advance-credit-date"
+                        "advance-credit-amount-float"
+                        "advance-credit-remark-staff"
                       ]
                     }
                   ]
@@ -61,6 +67,9 @@ query getCase($filter: [CaseFilterSetType]) {
                       }
                       ... on FloatAnswer {
                         FloatAnswerValue: value
+                      }
+                      ... on DateAnswer {
+                        DateAnswerValue: value
                       }
                       question {
                         meta

--- a/ember/app/styles/app.scss
+++ b/ember/app/styles/app.scss
@@ -64,3 +64,16 @@ main {
 .case-list-action-divider {
   height: 50px !important;
 }
+
+.text-divider {
+  display: flex;
+  align-items: center;
+}
+
+.text-divider::after {
+  content: "";
+  height: 1px;
+  background-color: $global-primary-background;
+  flex-grow: 1;
+  margin-left: 1rem;
+}

--- a/ember/app/ui/cases/detail/index/template.hbs
+++ b/ember/app/ui/cases/detail/index/template.hbs
@@ -70,13 +70,25 @@
     </span>
   </div>
   <div class="uk-width-2-3 uk-flex uk-flex-column">
+    {{#unless (or this.remarks this.permamentRemarks)}}
+      {{t "global.empty"}}
+    {{/unless}}
     {{#each this.remarks as |remark|}}
       <div class="uk-margin-bottom">
         <p class="uk-text-bold uk-margin-small-bottom">{{remark.label}}</p>
         <span>{{remark.value}}</span>
       </div>
-    {{else}}
-      {{t "global.empty"}}
+    {{/each}}
+    {{#each this.permamentRemarks as |remark|}}
+      <span class="uk-text-bold uk-margin-bottom text-divider">
+        {{remark.workItem.document.form.name}}
+      </span>
+      {{#each remark.answers as |answer|}}
+        <div class="uk-margin-bottom">
+          <p class="uk-text-bold uk-margin-small-bottom">{{answer.label}}</p>
+          <span>{{answer.value}}</span>
+        </div>
+      {{/each}}
     {{/each}}
   </div>
 </div>

--- a/ember/config/environment.js
+++ b/ember/config/environment.js
@@ -98,7 +98,7 @@ module.exports = function (environment) {
           "complete-document",
         ],
         manuallyCompletableTasks: ["complete-document"],
-        // when adding to displayAnswers, remeber to add to get-case.graphql
+        // when adding questions to displayAnswers, also add to get-case.graphql
         displayedAnswers: {
           // task slug
           "review-document": {
@@ -143,8 +143,16 @@ module.exports = function (environment) {
             "define-amount-decision-dismissed": ["define-amount-remark"],
           },
         },
+        // when adding questions to alwaysDisplayedAnswers, also add to get-case.graphql
+        // when adding a task, also add to CaseDetailIndexController remarkWorkItems filter
         alwaysDisplayedAnswers: {
           "decision-and-credit": ["gesprochener-rahmenkredit"],
+          "advance-credits": [
+            "advance-credit-date",
+            "advance-credit-amount-float",
+            "priorisierung-der-antrage-kommentar",
+            "advance-credit-remark-staff",
+          ],
         },
         orderTypeKeys: {
           attribute: [

--- a/ember/tests/unit/ui/cases/detail/index/controller-test.js
+++ b/ember/tests/unit/ui/cases/detail/index/controller-test.js
@@ -194,6 +194,8 @@ module("Unit | Controller | cases/detail/index", function (hooks) {
         label: "Kommentar",
         value: "Remarked",
       },
+    ]);
+    assert.deepEqual(controller.permamentRemarks[0].answers, [
       {
         label: "Gesprochener Rahmenkredit",
         value: "CHF 123.-",


### PR DESCRIPTION
`advance-credit-remark-staff` answer visibility is handled through the caluma visibility layer, there was a bug that all answers of a document were visible, but that has been fixed here as well.
Therefore no change in the frontend is necessary to hide that answer from non staff. 

<img width="818" height="572" alt="image" src="https://github.com/user-attachments/assets/33c4959d-bc46-4236-809e-77fe090addfc" />
