### PR TITLE
 fix(identity): only check for existing accesses in non withdrawn cases

### DIFF
--- a/ember/app/gql/queries/get-cancelled-cases.graphql
+++ b/ember/app/gql/queries/get-cancelled-cases.graphql
@@ -1,0 +1,11 @@
+query getCancelledCases($caseIds: [ID]) {
+  allCases(
+    filter: [{ids: $caseIds}, {status: CANCELED}]
+  ) {
+    edges {
+      node {
+        id,
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since cases which have been withdrawn are not visible anymore, it's confusing if you get a warning for existing access on one of those cases.

@open-dynaMIX This filters out `zurückgezogen`, should we also add `dismissed`? I'm missing domain knowledge if this makes sense to also filter out.