### PR TITLE
ci(schedule): only run on original repo

### DIFF
--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   scan:
+    if: github.repository == 'adfinis/mysagw'
     strategy:
       matrix:
         service: [api, caluma, ember]


### PR DESCRIPTION
Prevents the `schedule` workflow from running in forks.