### PR TITLE
fix(ember): optional chaining on access.identity

### DIFF
--- a/ember/app/abilities/-base.js
+++ b/ember/app/abilities/-base.js
@@ -55,7 +55,7 @@ export default class BaseAbility extends Ability {
     return Boolean(
       calumaCase.accesses.find(
         (access) =>
-          access.identity.idpId ===
+          access.identity?.idpId ===
           this.session.data.authenticated.userinfo.sub,
       ),
     );

--- a/ember/app/adapters/identity.js
+++ b/ember/app/adapters/identity.js
@@ -11,15 +11,15 @@ export default class IdentityAdapter extends ApplicationAdapter {
     return super.urlForFindRecord(id, modelName, snapshot);
   }
 
-  urlForQueryRecord() {
-    return `${this.buildURL()}/me`;
-  }
-
   urlForUpdateRecord(id, modelName, snapshot) {
     if (snapshot.adapterOptions?.customEndpoint) {
       return `${this.buildURL()}/${snapshot.adapterOptions.customEndpoint}`;
     }
 
     return super.urlForUpdateRecord(id, modelName, snapshot);
+  }
+
+  urlForQueryRecord() {
+    return `${this.buildURL()}/me`;
   }
 }

--- a/ember/app/components/identity-interests.js
+++ b/ember/app/components/identity-interests.js
@@ -141,13 +141,9 @@ export default class IdentityInterestsComponent extends Component {
       );
 
       try {
-        // Replacement for removeObject
-        const index = this.args.identity.interests.indexOf(interest);
-        if (index !== -1) {
-          this.args.identity.interests = [
-            ...this.args.identity.interests.toSpliced(index, 1),
-          ];
-        }
+        this.args.identity.interests = this.args.identity.interests.filter(
+          (i) => i !== interest,
+        );
         this.args.identity.save(this.endpoint);
 
         this.notification.success(

--- a/ember/app/components/identity-memberships.hbs
+++ b/ember/app/components/identity-memberships.hbs
@@ -12,7 +12,8 @@
               <LinkTo
                 @route="identities.edit"
                 @model={{membership.organisation.id}}
-                class="uk-text-bold {{if membership.isInactive 'text-strike-through'}}"
+                class="uk-text-bold
+                  {{if membership.isInactive 'text-strike-through'}}"
               >
                 {{~membership.organisation.organisationName~}}
               </LinkTo>

--- a/ember/app/models/identity.js
+++ b/ember/app/models/identity.js
@@ -25,7 +25,7 @@ export default class IdentityModel extends LocalizedModel {
   additionalEmails;
   @hasMany("phone-number", { inverse: "identity", async: true }) phoneNumbers;
   @hasMany("address", { inverse: "identity", async: true }) address;
-  @hasMany("interest", { inverse: null, async: true }) interests;
+  @hasMany("interest", { inverse: null, async: false }) interests;
 
   @hasMany("membership", { inverse: "identity", async: true }) memberships;
   @hasMany("membership", { inverse: "organisation", async: true }) members;

--- a/ember/app/profile/edit/route.js
+++ b/ember/app/profile/edit/route.js
@@ -7,6 +7,7 @@ export default class ProfileEditRoute extends Route {
   model({ identity }) {
     return this.store.findRecord("identity", identity, {
       adapterOptions: { customEndpoint: "my-orgs" },
+      reload: true,
     });
   }
 }

--- a/ember/app/profile/index/route.js
+++ b/ember/app/profile/index/route.js
@@ -3,9 +3,10 @@ import { service } from "@ember/service";
 
 export default class ProfileIndexRoute extends Route {
   @service session;
+  @service store;
 
   model() {
-    return this.session.identity;
+    return this.store.queryRecord("identity", {});
   }
 
   setupController(controller, post) {

--- a/ember/app/services/session.js
+++ b/ember/app/services/session.js
@@ -20,22 +20,21 @@ export default class CustomSession extends Session {
     if (!this.isAuthenticated) return null;
 
     try {
-      const data = yield Promise.all([
-        this.store.query(
-          "membership",
-          {
-            include: "organisation",
-          },
-          { adapterOptions: { customEndpoint: "my-memberships" } },
-        ),
-        this.store.queryRecord("identity", {}),
-      ]);
+      const memberships = yield this.store.query(
+        "membership",
+        {
+          include: "organisation",
+        },
+        { adapterOptions: { customEndpoint: "my-memberships" } },
+      );
+      const identity = yield this.store.queryRecord("identity", {});
 
       return {
-        memberships: data[0],
-        identity: data[1],
+        memberships,
+        identity,
       };
     } catch (error) {
+      console.error(error);
       this.invalidate();
 
       if (


### PR DESCRIPTION
This PR fixes the following maintenance regressions:
- Admins only: When visiting the identity admin for the own user, the session identity interests would be overwritten by the admin view identity interests (including non public). These are now refreshed.
- If for some reason, the backend returns a case access for a non registered user (so without identity), the fronted will no longer error.